### PR TITLE
Remove exclude files from Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -23,11 +23,9 @@ let package = Package(
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(
             name: "EasyTipView",
-            dependencies: [],
-            exclude: ["assets", "Example", "Source"]),
+            dependencies: []),
         .testTarget(
             name: "EasyTipViewTests",
-            dependencies: ["EasyTipView"],
-            exclude: ["assets", "Example", "Source"]),
+            dependencies: ["EasyTipView"])
     ]
 )


### PR DESCRIPTION
This PR fixes the warning invalid exclude: File not found